### PR TITLE
feat: Destroy task state on tab disconnect

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -61,9 +61,9 @@ export const Providers = () => {
     AccountsProvider,
 
     // Task: `chainExplorer` related providers.
-    ChainExplorerProvider,
     ChainFilterProvider,
     ChainStateProvider,
+    ChainExplorerProvider,
 
     // Task: `parachainSetup` related providers.
     ParaSetupProvider,

--- a/src/contexts/ChainExplorer/defaults.ts
+++ b/src/contexts/ChainExplorer/defaults.ts
@@ -12,6 +12,7 @@ export const defaultChainExplorerContext: ChainExplorerContextInterface = {
   updateUnit: (id, unit) => {},
   forgetTabChain: (tabId) => {},
   chainExplorerIntegrityCheck: (tabId) => false,
+  removeChainExplorerTaskState: (tabId) => {},
 };
 
 export const defaultCustomEndpointChainMeta = {

--- a/src/contexts/ChainExplorer/index.tsx
+++ b/src/contexts/ChainExplorer/index.tsx
@@ -24,6 +24,8 @@ import { useChainSpaceEnv } from 'contexts/ChainSpaceEnv';
 import { tabIdToOwnerId } from 'contexts/Tabs/Utils';
 import { useApiIndexer } from 'contexts/ApiIndexer';
 import type { IntegrityCheckedChainContext } from 'routes/Chain/Provider/types';
+import { useChainUi } from 'contexts/ChainUi';
+import { useChainState } from 'contexts/ChainState';
 
 export const ChainExplorer = createContext<ChainExplorerContextInterface>(
   defaultChainExplorerContext
@@ -45,7 +47,9 @@ export const ChainExplorerProvider = ({
     getAutoTabName,
   } = useTabs();
   const { autoTabNaming } = useSettings();
+  const { destroyTabChainUi } = useChainUi();
   const { getTabApiIndex } = useApiIndexer();
+  const { destroyTabChainState } = useChainState();
   const { handleConnectApi, getChainSpec } = useChainSpaceEnv();
 
   // Connect tab to an Api instance and update its chain data.
@@ -197,6 +201,12 @@ export const ChainExplorerProvider = ({
     };
   };
 
+  // Remove task related state on disconnect.
+  const removeChainExplorerTaskState = (tabId: number) => {
+    destroyTabChainUi(tabId);
+    destroyTabChainState();
+  };
+
   return (
     <ChainExplorer.Provider
       value={{
@@ -207,6 +217,7 @@ export const ChainExplorerProvider = ({
         forgetTabChain,
         connectChainExplorer,
         chainExplorerIntegrityCheck,
+        removeChainExplorerTaskState,
       }}
     >
       {children}

--- a/src/contexts/ChainExplorer/types.ts
+++ b/src/contexts/ChainExplorer/types.ts
@@ -21,6 +21,7 @@ export interface ChainExplorerContextInterface {
   chainExplorerIntegrityCheck: (
     tabId: number
   ) => IntegrityCheckedChainContext | false;
+  removeChainExplorerTaskState: (tabId: number) => void;
 }
 
 export interface ChainExplorerTaskData {

--- a/src/contexts/ChainState/defaults.ts
+++ b/src/contexts/ChainState/defaults.ts
@@ -13,4 +13,5 @@ export const defaultChainStateContext: ChainStateContextInterface = {
   chainStateConstants: {},
   setItemPinned: (type, subscriptionKey, pinned) => {},
   getTotalPinnedItems: () => 0,
+  destroyTabChainState: () => {},
 };

--- a/src/contexts/ChainState/index.tsx
+++ b/src/contexts/ChainState/index.tsx
@@ -40,7 +40,9 @@ export const useChainState = () => useContext(ChainState);
 export const ChainStateProvider = ({ children }: { children: ReactNode }) => {
   const { tabId, ownerId } = useActiveTab();
   const { getTabApiIndex } = useApiIndexer();
-  const apiInstanceId = getTabApiIndex(ownerId, 'chainExplorer')?.instanceId;
+
+  const tabApiIndex = getTabApiIndex(ownerId, 'chainExplorer');
+  const apiInstanceId = tabApiIndex?.instanceId;
 
   // The results of current chain state subscriptions, keyed by subscription key.
   const [chainStateSubscriptions, setChainStateSubscriptionsState] =
@@ -219,6 +221,19 @@ export const ChainStateProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  // Reset state for a tab.
+  const destroyTabChainState = () => {
+    if (!apiInstanceId) {
+      return;
+    }
+    // Destroy API instance.
+    ChainStateController.destroy(apiInstanceId);
+
+    // Reset state.
+    setChainStateSubscriptions({});
+    setChainStateConstants({});
+  };
+
   // Get chain state on tab change.
   useEffectIgnoreInitial(() => {
     if (!apiInstanceId) {
@@ -242,6 +257,7 @@ export const ChainStateProvider = ({ children }: { children: ReactNode }) => {
         setConstant,
         setItemPinned,
         getTotalPinnedItems,
+        destroyTabChainState,
       }}
     >
       {children}

--- a/src/contexts/ChainState/types.ts
+++ b/src/contexts/ChainState/types.ts
@@ -24,6 +24,7 @@ export interface ChainStateContextInterface {
     pinned: boolean
   ) => void;
   getTotalPinnedItems: () => number;
+  destroyTabChainState: () => void;
 }
 
 // Chain state subscriptions for a tab, keyed by subscription key.

--- a/src/contexts/ChainUi/index.tsx
+++ b/src/contexts/ChainUi/index.tsx
@@ -214,7 +214,7 @@ export const ChainUiProvider = ({ children }: { children: ReactNode }) => {
     setInputArgs(updatedInputArgs);
   };
 
-  // Reset input args for a tab.
+  // Reset state for a tab.
   const destroyTabChainUi = (tabId: number) => {
     const updatedChainUi = { ...chainUi };
     delete updatedChainUi[tabId];
@@ -222,9 +222,13 @@ export const ChainUiProvider = ({ children }: { children: ReactNode }) => {
     const updatedChainStateSections = { ...chainStateSections };
     delete updatedChainStateSections[tabId];
 
+    const updatedChainStateFilters = { ...activeChainStateFilters };
+    delete updatedChainStateFilters[tabId];
+
     const updatedInputArgs = { ...inputArgsRef.current };
     delete updatedInputArgs[tabId];
 
+    setActiveChainStateFilters(updatedChainStateFilters);
     setChainUi(updatedChainUi);
     setChainStateSections(updatedChainStateSections);
     setInputArgs(updatedInputArgs);

--- a/src/routes/Common/ManageTab/index.tsx
+++ b/src/routes/Common/ManageTab/index.tsx
@@ -16,14 +16,17 @@ import { useChainExplorer } from 'contexts/ChainExplorer';
 import { useChainSpaceEnv } from 'contexts/ChainSpaceEnv';
 import { useApiIndexer } from 'contexts/ApiIndexer';
 import { useSettings } from 'contexts/Settings';
+import { useParaSetup } from 'contexts/ParaSetup';
 
 export const ManageTab = () => {
   const { autoTabNaming } = useSettings();
   const { getTabApiIndexes } = useApiIndexer();
   const { tab, tabId, ownerId } = useActiveTab();
+  const { destroyTabParaSetup } = useParaSetup();
   const { destroyAllApiInstances } = useChainSpaceEnv();
   const { renameTab, getTabActiveTask, getAutoTabName } = useTabs();
-  const { updateSs58, updateUnits, updateUnit } = useChainExplorer();
+  const { updateSs58, updateUnits, updateUnit, removeChainExplorerTaskState } =
+    useChainExplorer();
 
   const activeTask = getTabActiveTask(tabId);
   const apiInstances = getTabApiIndexes(ownerId);
@@ -34,10 +37,14 @@ export const ManageTab = () => {
     tab?.taskData?.chain !== undefined &&
     !isDirectoryId(tab.taskData.chain?.id || '');
 
-  // Handle disconnecting from API.
-  const handleDisconnectApi = () => {
+  // Handle disconnecting from tab.
+  const handleDisconnectTab = () => {
     if (window.confirm('Are you sure you want to disconnect this tab?')) {
       destroyAllApiInstances(ownerId);
+
+      // Reset task related state.
+      removeChainExplorerTaskState(tabId);
+      destroyTabParaSetup(tabId);
 
       // Reset tab name if auto naming is enabled.
       if (autoTabNaming) {
@@ -122,7 +129,7 @@ export const ManageTab = () => {
             <div className="buttons">
               <button
                 onClick={() => {
-                  handleDisconnectApi();
+                  handleDisconnectTab();
                 }}
               >
                 Disconnect from API


### PR DESCRIPTION
Destroys task related state on intentional tab disconnects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tab management with new functions to handle tab disconnection and state reset.
  
- **Improvements**
  - Improved state management within the app by introducing functions to remove task-related states and reset tab-specific states.

- **Bug Fixes**
  - Ensured proper cleanup of state and resources when tabs are disconnected, improving overall app stability.

- **Refactor**
  - Reorganized provider components for better clarity and maintainability.

- **Documentation**
  - Updated internal component documentation to reflect new functions and their purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->