### PR TITLE
fix: `labelsOnly` as class member, fix recursion

### DIFF
--- a/src/canvas/RuntimeSnapshot/PalletItem.tsx
+++ b/src/canvas/RuntimeSnapshot/PalletItem.tsx
@@ -61,7 +61,7 @@ export const PalletItem = ({ pallet, scraper }: PalletItemProps) => {
       return;
     }
     fetchingStorageRef.current = 'syncing';
-    const result = name ? scraper.getStorage(name, { labelsOnly: true }) : [];
+    const result = name ? scraper.getStorage(name) : [];
     fetchingStorageRef.current = 'synced';
     setStorageItems(result);
   };

--- a/src/model/Scraper/Pallet.ts
+++ b/src/model/Scraper/Pallet.ts
@@ -24,6 +24,7 @@ export class PalletScraper extends MetadataScraper {
     metadata: MetadataVersion,
     config: ScraperConfig = {
       maxDepth: 7,
+      labelsOnly: false,
     }
   ) {
     super(metadata, config);

--- a/src/model/Scraper/types.ts
+++ b/src/model/Scraper/types.ts
@@ -81,10 +81,10 @@ export interface PalletListItem {
 
 export interface ScraperConfig {
   maxDepth: number | '*';
+  labelsOnly: boolean;
 }
 
 export interface ScraperOptions {
-  labelsOnly?: boolean;
   maxDepth?: number | '*';
   parentTrailId?: TrailParentId;
   indexPrefix?: string;
@@ -99,7 +99,6 @@ export interface TypeParams {
   trailId: TrailId;
   parent: TrailParentId;
   indexKey: string;
-  labelsOnly: boolean;
   maxDepth: number | '*';
 }
 

--- a/src/routes/Chain/ChainState/Constants.tsx
+++ b/src/routes/Chain/ChainState/Constants.tsx
@@ -29,7 +29,7 @@ export const Constants = () => {
   const chainUi = getChainUi(tabId, chainUiSection);
   const Metadata = chainSpec.metadata;
 
-  // Fetch storage data when metadata or the selected pallet changes.
+  // Fetch constants when metadata or the selected pallet changes.
   const scraperResult = useMemo(() => {
     // Get pallet list from scraper.
     const scraper = new PalletScraper(Metadata);

--- a/src/routes/Chain/ChainState/StorageItems.tsx
+++ b/src/routes/Chain/ChainState/StorageItems.tsx
@@ -32,16 +32,17 @@ export const StorageItems = () => {
   // Fetch storage items when metadata or the selected pallet changes.
   const scrapedStorageList = useMemo(() => {
     // Get pallet list from scraper.
-    const scraper = new PalletScraper(Metadata, { maxDepth: 7 });
+    const scraper = new PalletScraper(Metadata, {
+      maxDepth: 7,
+      labelsOnly: true,
+    });
     const pallets = scraper.getPalletList([chainUiSection]);
 
     // If no pallet selected, get first one from scraper or fall back to null.
     const activePallet = chainUi.pallet || pallets?.[0].name || null;
 
     // Get storage items for the active pallet.
-    const palletStorage = activePallet
-      ? scraper.getStorage(activePallet, { labelsOnly: true })
-      : [];
+    const palletStorage = activePallet ? scraper.getStorage(activePallet) : [];
 
     // Sort the storage items by name.
     const items = palletStorage.sort(({ name: nameA }, { name: nameB }) =>
@@ -71,7 +72,10 @@ export const StorageItems = () => {
       return { scrapedItem: null, scraper: null };
     }
 
-    const scraper = new PalletScraper(Metadata, { maxDepth: '*' });
+    const scraper = new PalletScraper(Metadata, {
+      maxDepth: '*',
+      labelsOnly: false,
+    });
     const scrapedItem = scraper.getStorageItem(activePallet, activeItem);
 
     return { scrapedItem, scraper };

--- a/src/routes/Chain/Extrinsics/index.tsx
+++ b/src/routes/Chain/Extrinsics/index.tsx
@@ -43,7 +43,10 @@ export const Extrinsics = () => {
 
   // Fetch storage data when metadata or the selected pallet changes.
   const callData = useMemo((): PalletData => {
-    const scraper = new PalletScraper(Metadata, { maxDepth: 7 });
+    const scraper = new PalletScraper(Metadata, {
+      maxDepth: 7,
+      labelsOnly: true,
+    });
     const pallets = scraper.getPalletList([chainUiSection]);
 
     // If no pallet selected, get first one from scraper or fall back to null.
@@ -76,7 +79,10 @@ export const Extrinsics = () => {
       return null;
     }
 
-    const scraper = new PalletScraper(Metadata, { maxDepth: '*' });
+    const scraper = new PalletScraper(Metadata, {
+      maxDepth: '*',
+      labelsOnly: false,
+    });
     const scrapedItem = scraper.getCallItem(activePallet, activeItem);
 
     return { scrapedItem, scraper };


### PR DESCRIPTION
Fixes `labelsOnly` recursion and moves `labelsOnly` to a scraper class member.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fetching of storage items in the PalletItem component to ensure comprehensive data retrieval.

- **Refactor**
  - Simplified the `scraper.getStorage` method by removing the `labelsOnly` parameter, enhancing code clarity and maintainability.

- **Documentation**
  - Updated comments to accurately reflect the data fetching process in the Constants component.

- **New Features**
  - Introduced a new `labelsOnly` configuration option for the `PalletScraper` to provide more flexible data retrieval options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->