### PR TITLE
feat: immediately show result box

### DIFF
--- a/src/contexts/ChainState/index.tsx
+++ b/src/contexts/ChainState/index.tsx
@@ -105,10 +105,6 @@ export const ChainStateProvider = ({ children }: { children: ReactNode }) => {
     // temporary invalid subscription.
     const filteredEntries = Object.entries(chainStateSubscriptions).filter(
       ([, subscription]) => {
-        if (subscription.result === undefined) {
-          return false;
-        }
-
         if (type === undefined) {
           return true;
         }

--- a/src/routes/Chain/ChainState/Results/Result.tsx
+++ b/src/routes/Chain/ChainState/Results/Result.tsx
@@ -27,11 +27,12 @@ export const ChainStateResult = ({
 
   // Determine whether the result is empty.
   const isEmpty =
-    [undefined, null, ''].includes(resultJson) ||
+    [null, ''].includes(resultJson) ||
     (Array.isArray(resultJson) && resultJson.length === 0);
 
   // Format the JSON for display if it is not empty.
-  const display = !isEmpty ? formatJSON(resultJson) : 'None';
+  const display =
+    result === undefined ? '...' : !isEmpty ? formatJSON(resultJson) : 'None';
 
   return (
     <section>


### PR DESCRIPTION
Immedately show a subscription result box to give the user feedback the subscription was submitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated filtering logic in the `ChainStateProvider` function to handle subscriptions more accurately.
  - Improved handling of subscription configuration and result storage in the `ChainState` class.
  - Updated result check logic in `Result.tsx` to include `result` being `undefined`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->