### PR TITLE
feat: `useInput` label amendments

### DIFF
--- a/src/model/Scraper/ArgBuilder.ts
+++ b/src/model/Scraper/ArgBuilder.ts
@@ -7,6 +7,7 @@ import type { InputMeta } from 'routes/Chain/Inputs/types';
 import type { PalletScraper } from './Pallet';
 import type { CompositeType } from './Types/Composite';
 import type { VariantType } from './Types/Variant';
+import { getParentKey } from './Utils';
 
 // A class to take input keys and values, and formats them into a submittable array of arguments.
 export class ArgBuilder {
@@ -144,8 +145,8 @@ export class ArgBuilder {
     // Concatenate deepest key values to each corresponding parent key.
     const parentKeysWithValues = Object.entries(sortedDeepestKeys).reduce(
       (acc: Record<string, AnyJson[]>, [key]) => {
-        // Split key by underscore and remove the last element to get the parent key.
-        const parentKey = key.split('_').slice(0, -1).join('_');
+        // Get parent index key.
+        const parentKey = getParentKey(key);
 
         // Get the current value of this parent key if it exists.
         const currentValue = acc[parentKey] || [];

--- a/src/model/Scraper/CallSignature.ts
+++ b/src/model/Scraper/CallSignature.ts
@@ -107,11 +107,11 @@ export class FormatCallSignature {
         break;
 
       case 'primitive':
-        str = typeClass.label();
+        str = typeClass.label;
         break;
 
       case 'bitSequence':
-        str = typeClass.label();
+        str = typeClass.label;
         break;
 
       case 'sequence':
@@ -136,7 +136,7 @@ export class FormatCallSignature {
   // Formats a string from a composite type.
   getCompositeString = (arg: ScrapedItem) => {
     const typeClass = this.scraper.getClass(arg.indexKey);
-    const label = typeClass.label();
+    const label = typeClass.label;
 
     let str = '';
     // Expand type if short label is not defined, or if they've been defined in ignore list.
@@ -161,7 +161,7 @@ export class FormatCallSignature {
   // Formats a string from a variant type.
   getVariantType = (arg: ScrapedItem) => {
     const typeClass = this.scraper.getClass(arg.indexKey);
-    const label = typeClass.label();
+    const label = typeClass.label;
 
     let str = `${label}`;
 

--- a/src/model/Scraper/Types/Common/Base.ts
+++ b/src/model/Scraper/Types/Common/Base.ts
@@ -22,22 +22,22 @@ export class Base {
   // The index key for this type.
   indexKey: string;
 
+  // The label for this type. (the last index of lookup path).
+  label: string;
+
   constructor({ lookup, depth, trail, indexKey }: BaseParams) {
     this.lookup = lookup;
     this.depth = depth;
     this.trail = trail;
     this.indexKey = indexKey;
+
+    const { path } = this.lookup.type;
+    this.label = path[path.length - 1];
   }
 
   // Get the full path of this type.
   path() {
     const { path, params } = this.lookup.type;
     return typeToString(path, params);
-  }
-
-  // Get the label of this type (the last index of the path).
-  label() {
-    const { path } = this.lookup.type;
-    return path[path.length - 1];
   }
 }

--- a/src/model/Scraper/Types/Composite.ts
+++ b/src/model/Scraper/Types/Composite.ts
@@ -26,7 +26,7 @@ export class CompositeType extends Base implements MetadataType {
 
   // Get the input component of this type.
   input() {
-    let label = this.label();
+    let label = this.label;
 
     // If this composite is a sequence of u8s, then change the label to `Bytes`.
     if (compositeIsBytes(label, this)) {

--- a/src/model/Scraper/Types/Primitive.ts
+++ b/src/model/Scraper/Types/Primitive.ts
@@ -14,11 +14,7 @@ export class PrimitiveType extends Base implements MetadataType {
   constructor(primitive: string, base: BaseParams) {
     super(base);
     this.primitive = primitive;
-  }
-
-  // Get the label of this primitive.
-  override label() {
-    return this.primitive.toLowerCase();
+    this.label = this.primitive.toLowerCase();
   }
 
   // Get the input type of this primitive.

--- a/src/model/Scraper/Types/Sequence.ts
+++ b/src/model/Scraper/Types/Sequence.ts
@@ -22,7 +22,7 @@ export class SequenceType extends Base implements MetadataType {
   // Sequences contain one or more child inputs that should be wrapped in an multi-select array
   // input.
   input() {
-    let label = this.label();
+    let label = this.label;
 
     // If this sequence is a sequence of bytes, then change the label to `Bytes`.
     if (sequenceIsBytes(label)) {

--- a/src/model/Scraper/Types/types.ts
+++ b/src/model/Scraper/Types/types.ts
@@ -93,7 +93,7 @@ export abstract class MetadataType {
   abstract depth: number;
 
   // All metadata type classes must return a label.
-  abstract label(): string;
+  abstract label: string;
 
   // All metadata type classes must return their input types.
   abstract input(): string | null;

--- a/src/model/Scraper/Utils.ts
+++ b/src/model/Scraper/Utils.ts
@@ -23,6 +23,14 @@ export const defaultInputValue = (type: string): string => {
 };
 
 // ------------------------------------------------------
+// Index key utils.
+// ------------------------------------------------------
+
+// Get the parent key from an index key.
+export const getParentKey = (key: string): string =>
+  key.split('_').slice(0, -1).join('_');
+
+// ------------------------------------------------------
 // Options.
 // ------------------------------------------------------
 

--- a/src/routes/Chain/Inputs/useInput.tsx
+++ b/src/routes/Chain/Inputs/useInput.tsx
@@ -106,8 +106,9 @@ export const useInput = () => {
 
   // Renders an array input component.
   const renderArray = (arg: ScrapedItem, config: InputArgConfig) => {
-    const typeClass = config.scraper.getClass(arg.indexKey) as ArrayType;
-    const label = typeClass.label();
+    const { indexKey } = arg;
+    const typeClass = config.scraper.getClass(indexKey) as ArrayType;
+    const label = typeClass.label;
 
     // If array is a vector of bytes, render a hash input.
     if (arrayIsBytes(arg)) {
@@ -140,8 +141,8 @@ export const useInput = () => {
   ) => {
     const { indexKey } = arg;
     const typeClass = config.scraper.getClass(indexKey) as SequenceType;
-    const label = typeClass.label();
     const input = typeClass.input();
+    const label = typeClass.label;
 
     // If sequence is a vector of bytes, render a hash input.
     if (input !== 'array') {
@@ -187,9 +188,9 @@ export const useInput = () => {
   const renderComposite = (arg: ScrapedItem, config: InputArgConfig) => {
     const { indexKey } = arg;
     const typeClass = config.scraper.getClass(indexKey) as CompositeType;
-    const label = typeClass.label();
     const input = typeClass.input();
     const { inputKey, inputMeta } = config;
+    const label = typeClass.label;
 
     // If this composite is a custom input, render it and stop the recursive input loop.
     if (input !== 'indent') {
@@ -255,9 +256,19 @@ export const useInput = () => {
                 const { typeName, ...rest } = field;
                 const childKey = `${inputKey}_${index}`;
 
+                const childTypeClass = config.scraper.getClass(field.indexKey);
+                const childLabel = childTypeClass.label;
+
+                // Check if the child label is the same as the parent label. Compact types will
+                // always have a label, so we can ignore this one.
+                const duplicateLabel =
+                  childLabel === typeName || childTypeClass.type === 'compact';
+
                 return (
                   <Fragment key={`input_arg_${childKey}`}>
-                    <h4 className="standalone">{typeName}</h4>
+                    {!duplicateLabel && (
+                      <h4 className="standalone">{typeName}</h4>
+                    )}
                     {readInput(rest, { ...config, inputKey: childKey })}
                   </Fragment>
                 );
@@ -272,7 +283,7 @@ export const useInput = () => {
   // Renders an input component wrapped in an input section.
   const renderInput = (
     arg: ScrapedItem,
-    inputArgConfig: InputArgConfig,
+    config: InputArgConfig,
     options?: {
       indent?: boolean;
       prependLabel?: string;
@@ -293,7 +304,7 @@ export const useInput = () => {
       namespace,
       activePallet,
       activeItem,
-    } = inputArgConfig;
+    } = config;
 
     const { indexKey } = arg;
     const typeClass = scraper.getClass(indexKey);
@@ -302,9 +313,9 @@ export const useInput = () => {
     const keys = { inputKey, indexKey };
 
     // Determine input label.
-    const label = !typeClass.label()
+    const label = !typeClass.label
       ? undefined
-      : `${prependLabel ? `${prependLabel} ` : ``}${typeClass.label()}`;
+      : `${prependLabel ? `${prependLabel} ` : ``}${typeClass.label}`;
 
     // Get the input type.
     const input = overrideInput || typeClass.input();
@@ -372,12 +383,12 @@ export const useInput = () => {
                   // Child inputs changed - remove args.
                   resetInputArgsFromKey(
                     tabId,
-                    inputArgConfig.namespace,
-                    inputArgConfig.inputKey,
+                    config.namespace,
+                    config.inputKey,
                     false
                   );
                   // Commit new input arg value.
-                  setInputArgAtKey(tabId, inputArgConfig.namespace, keys, val);
+                  setInputArgAtKey(tabId, config.namespace, keys, val);
                 }}
               />
             </Section>


### PR DESCRIPTION
Prevents duplicate labels when a variant label was the same as its inner value. Also amends metadata type class `label` from a method to a class member.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic in `ArgBuilder.ts` to improve parent key retrieval.
  - Modified the `FormatCallSignature` class to enhance string formatting.
  - Updated the `Base` class to include a new `label` property.
  - Improved label handling in the `CompositeType` class.
  - Integrated primitive type functionality into the `PrimitiveType` class constructor.
  - Enhanced label assignment in the `SequenceType` class.
  - Changed method signature in the `MetadataType` abstract class.
  - Added a `getParentKey` utility function in `Utils.ts`.
  - Adjusted logic and rendering in the `useInput` function within `useInput.tsx`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->