### PR TITLE
feat: Check ledger generic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@zondax/ledger-substrate": "^0.44.2",
     "bignumber.js": "^9.1.2",
     "buffer": "^6.0.3",
+    "compare-versions": "^6.1.1",
     "date-fns": "^3.3.1",
     "framer-motion": "^11.1.7",
     "html5-qrcode": "^2.3.8",

--- a/src/contexts/LedgerHardware/index.tsx
+++ b/src/contexts/LedgerHardware/index.tsx
@@ -15,6 +15,7 @@ import type {
 } from './types';
 import { Ledger } from './static/ledger';
 import type { AnyJson } from '@w3ux/types';
+import { compare } from 'compare-versions';
 
 export const LedgerHardwareContext =
   createContext<LedgerHardwareContextInterface>(defaultLedgerHardwareContext);
@@ -89,6 +90,17 @@ export const LedgerHardwareProvider = ({
       const { app } = await Ledger.initialise(txMetadataChainId);
       const result = await Ledger.getVersion(app);
       const major = result?.major || 0;
+      const minor = result?.minor || 0;
+      const patch = result?.major || 0;
+
+      // The current version of the Polkadot Ledger app.
+      const currentSemVer = `${major}.${minor}.${patch}`;
+
+      // The version the Generic Polkadot Ledger app was introduced.
+      const genericLaunchSemVer = '100.0.5';
+
+      // Check if the current version is upgraded for the Generic Polkadot Ledger app.
+      const isLegacy = compare(currentSemVer, genericLaunchSemVer, '<');
 
       if (Ledger.isError(result)) {
         throw new Error(result.error_message);
@@ -97,7 +109,9 @@ export const LedgerHardwareProvider = ({
       setIsExecuting(false);
       resetFeedback();
 
-      if (major < transactionVersion) {
+      // If the current version is less than the transaction version, or the app is not the generic
+      // app, set the runtimesInconsistent flag.
+      if (major < transactionVersion || isLegacy) {
         runtimesInconsistent.current = true;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4832,6 +4832,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compare-versions@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "compare-versions@npm:6.1.1"
+  checksum: 10c0/415205c7627f9e4f358f571266422980c9fe2d99086be0c9a48008ef7c771f32b0fbe8e97a441ffedc3910872f917a0675fe0fe3c3b6d331cda6d8690be06338
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -5196,6 +5203,7 @@ __metadata:
     "@zondax/ledger-substrate": "npm:^0.44.2"
     bignumber.js: "npm:^9.1.2"
     buffer: "npm:^6.0.3"
+    compare-versions: "npm:^6.1.1"
     date-fns: "npm:^3.3.1"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"


### PR DESCRIPTION
Checks if Polkadot Ledger app is the generic version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced version-checking capabilities for the Ledger app, improving how the application manages compatibility with different versions.
  
- **Bug Fixes**
  - Improved robustness of version management to accurately flag inconsistencies based on major version discrepancies and legacy app statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->